### PR TITLE
Replace new Buffer() with Buffer.from()

### DIFF
--- a/Node.js/03. Export Rendered Report to PDF-file/index.js
+++ b/Node.js/03. Export Rendered Report to PDF-file/index.js
@@ -22,7 +22,7 @@ console.log("Report rendered. Pages count: ", report.renderedPages.count);
 var pdfData = report.exportDocument(Stimulsoft.Report.StiExportFormat.Pdf);
 			
 // Converting Array into buffer
-var buffer = new Buffer(pdfData, "utf-8")
+var buffer = Buffer.from(pdfData);
 
 // File System module
 var fs = require('fs');


### PR DESCRIPTION
Howdy Stimulsoft team!

This pull request replaces an occurrence of `new Buffer()` in this example, which is deprecated in Node core.

There are 3 things going on here:
- `new Buffer()` is deprecated in Node.js core as of the current LTS release  (see https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_new_buffer_array)
- Node likes this encoding to be expressed as "utf8", not "utf-8"   (see https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_buffers_and_character_encodings)
- the 2nd argument (input encoding) to new Buffer() is not relevant when creating a Buffer from an array (only when creating a Buffer from a string), because the source array instance isn't encoded.  (See https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_class_method_buffer_from_array versus https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_class_method_buffer_from_string_encoding)

Thank you!